### PR TITLE
Fix exports navigation in labs 1.2 and 1.3

### DIFF
--- a/site/docs/lab1/2_pull_based_telemetry.md
+++ b/site/docs/lab1/2_pull_based_telemetry.md
@@ -94,7 +94,11 @@ Now that we have service discovery configured for our Kubernetes cluster, let's 
 
     ![Alloy UI Graph](./img/discovery_graph.png)
 
-1.  **Click the box** for the `discovery.relabel` component.
+1.  The graph view doesn't have a left-hand navigation, so click **Remote Configuration** in the top navigation to go back.
+
+1.  Click the **View** button next to the **lab_scrape_telemetry.default** pipeline again.
+
+1.  Click the `discovery.relabel` component in the list of components.
 
 1.  Click the **Exports** link in the left navigation.
 

--- a/site/docs/lab1/3_push_based_telemetry.md
+++ b/site/docs/lab1/3_push_based_telemetry.md
@@ -90,7 +90,11 @@ Now that we have profiles being ingested, let's check the Alloy UI to see what i
 
     ![Alloy UI Graph](./img/traces_graph.png)
 
-1.  **Click the block** for the `discovery.relabel` component.
+1.  The graph view doesn't have a left-hand navigation, so click **Remote Configuration** in the top navigation to go back.
+
+1.  Click the **View** button next to the **lab_receive_telemetry.default** pipeline again.
+
+1.  Click the `discovery.relabel` component in the list of components.
 
 1.  Click the **Exports** link in the left navigation.
 


### PR DESCRIPTION
Graph view has no left-hand nav. Point users back to Remote Configuration and the component list to reach the Exports section instead.